### PR TITLE
you can compile on windows now

### DIFF
--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -249,7 +249,7 @@ config_load(FsearchConfig *config) {
 
         // Applications
 #ifdef _WIN32
-        config->folder_open_cmd = config_load_string(key_file, "Applications", "folder_open_cmd", "explorer \"%p\"");
+        config->folder_open_cmd = config_load_string(key_file, "Applications", "folder_open_cmd", "explorer.exe \"{path_full_raw}\"");
 #else
         config->folder_open_cmd = config_load_string(key_file, "Applications", "folder_open_cmd", NULL);
 #endif

--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -248,7 +248,11 @@ config_load(FsearchConfig *config) {
         config->show_dialog_failed_opening = config_load_boolean(key_file, "Dialogs", "show_dialog_failed_opening", true);
 
         // Applications
+#ifdef _WIN32
+        config->folder_open_cmd = config_load_string(key_file, "Applications", "folder_open_cmd", "explorer \"%p\"");
+#else
         config->folder_open_cmd = config_load_string(key_file, "Applications", "folder_open_cmd", NULL);
+#endif
 
         // Window
         config->restore_window_size = config_load_boolean(key_file, "Interface", "restore_window_size", false);

--- a/src/fsearch_database_entry.c
+++ b/src/fsearch_database_entry.c
@@ -1,4 +1,8 @@
 #include "fsearch_database_entry.h"
+
+#ifdef _WIN32
+#include "win32_compat.h"
+#endif
 #include "fsearch_file_utils.h"
 #include "fsearch_string_utils.h"
 
@@ -6,7 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef __MACH__
+#if defined(__MACH__) || defined(_WIN32)
 #include "strverscmp.h"
 #endif
 

--- a/src/fsearch_database_entry.h
+++ b/src/fsearch_database_entry.h
@@ -4,6 +4,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef _WIN32
+#include "win32_compat.h"
+#else
+#include <sys/types.h>
+#endif
+
 typedef enum {
     DATABASE_ENTRY_TYPE_NONE,
     DATABASE_ENTRY_TYPE_FOLDER,

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -23,7 +23,7 @@
 #include "fsearch_string_utils.h"
 #include "fsearch_ui_utils.h"
 
-#ifndef __MACH__
+#if !defined(__MACH__) && !defined(_WIN32)
 #include <gio/gdesktopappinfo.h>
 #endif
 
@@ -241,7 +241,7 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
             if (!path) {
                 continue;
             }
-            #ifdef __MACH__
+            #if defined(__MACH__) || defined(_WIN32)
             GAppInfo *desktop_app_info = g_app_info_create_from_commandline("/usr/bin/open", NULL, G_APP_INFO_CREATE_NONE, NULL);
             #else
             GDesktopAppInfo *desktop_app_info = g_desktop_app_info_new_from_filename(path);
@@ -265,12 +265,24 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
 
     GAppInfo *app_info = g_app_info_get_default_for_type(content_type, FALSE);
     if (!app_info) {
-        add_error_message_with_format(ctx->error_messages,
-                                      C_("Will be followed by the content type string.",
-                                         "Error when getting information for content type"),
-                                      content_type,
-                                      _("No default application registered"));
-        return;
+#ifdef _WIN32
+        // On Windows, if no default application is registered for directory content types,
+        // fall back to using explorer.exe directly
+        if (strcmp(content_type, "application/x-directory") == 0 || strcmp(content_type, "inode/directory") == 0) {
+            app_info = g_app_info_create_from_commandline("explorer.exe", "File Explorer", G_APP_INFO_CREATE_NONE, NULL);
+            if (app_info) {
+                g_debug("[Windows] Using explorer.exe fallback for directory content type: %s", content_type);
+            }
+        }
+#endif
+        if (!app_info) {
+            add_error_message_with_format(ctx->error_messages,
+                                          C_("Will be followed by the content type string.",
+                                             "Error when getting information for content type"),
+                                          content_type,
+                                          _("No default application registered"));
+            return;
+        }
     }
 
     FsearchFileUtilsLaunchUrisContext *launch_uris_ctx = g_new0(FsearchFileUtilsLaunchUrisContext, 1);
@@ -573,7 +585,7 @@ fsearch_file_utils_get_file_type(const char *name, gboolean is_dir) {
 
 GIcon *
 fsearch_file_utils_get_desktop_file_icon(const char *path) {
-    #ifdef __MACH__
+    #if defined(__MACH__) || defined(_WIN32)
     g_autoptr(GAppInfo) info = NULL;
     #else
     g_autoptr(GAppInfo) info = (GAppInfo *)g_desktop_app_info_new_from_filename(path);
@@ -655,6 +667,15 @@ fsearch_file_utils_get_content_type(const char *path, GError **error) {
         return NULL;
     }
     const char *content_type = g_file_info_get_content_type(info);
+    
+#ifdef _WIN32
+    // On Windows, GLib sometimes returns Unix-style content types like "inode/directory"
+    // which Windows doesn't understand. Convert them to Windows-compatible types.
+    if (content_type && strcmp(content_type, "inode/directory") == 0) {
+        return g_strdup("application/x-directory");
+    }
+#endif
+    
     return content_type ? g_strdup(content_type) : NULL;
 }
 

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -268,8 +268,6 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
             #if defined(__MACH__)
             GAppInfo *desktop_app_info = g_app_info_create_from_commandline("/usr/bin/open", NULL, G_APP_INFO_CREATE_NONE, NULL);
             #elif defined(_WIN32)
-            // On Windows, desktop files don't exist in the same way, so we just return NULL
-            // This will cause the fallback behavior to be used <- WRONG WRONG WRONG
             GAppInfo *desktop_app_info = NULL;
             #else
             GDesktopAppInfo *desktop_app_info = g_desktop_app_info_new_from_filename(path);
@@ -295,11 +293,6 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
     g_debug("[open_files] Looking for default app for content type: %s, found: %s", 
             content_type, app_info ? "yes" : "no");
 	#ifdef _WIN32
-    //APP info is NOT FALSE HERE
-        // On Windows, if no default application is registered for directory content types,
-        // we need to handle directories specially by launching explorer.exe with the path
-            // For directories on Windows, we launch explorer.exe individually for each path
-            // instead of trying to batch them, since explorer.exe needs the specific path
             for (uint32_t i = 0; i < files->len; ++i) {
                 GFile *file = g_ptr_array_index(files, i);
                 g_autofree char *path = g_file_get_path(file);
@@ -319,8 +312,6 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
                 }
             }
             return;
-        // For non-directory files on Windows, try to use the system default
-        // This should work for most file types including images
         #endif
 
     if (!app_info) {
@@ -365,7 +356,6 @@ handle_callback(FsearchFileUtilsOpenCallback callback, gpointer callback_data, G
 
 static void
 handle_queued_uris(FsearchFileUtilsLaunchContext *launch_ctx) {
-	   printf("handle_quiued_uris\r\n");
     if (g_queue_is_empty(launch_ctx->launch_uris_ctx_queue)) {
         // All files were handled, either successfully or with errors
         handle_callback(launch_ctx->callback, launch_ctx->callback_data, launch_ctx->error_messages);

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -541,7 +541,6 @@ fsearch_file_utils_open_path_list(GList *paths,
 
 static bool
 fsearch_file_utils_open_path_with_command(const char *path, const char *cmd, GString *error_message) {
-	//ON WINDOWS THIS IS NOT OPENNG THE PARENT PATH BUT THE FILE ITSELF
     g_autoptr(GFile) file = g_file_new_for_path(path);
     g_autoptr(GFile) parent = g_file_get_parent(file);
     // If file has no parent it means it's the root directory.

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -292,6 +292,8 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
     }
 
     GAppInfo *app_info = g_app_info_get_default_for_type(content_type, FALSE);
+    g_debug("[open_files] Looking for default app for content type: %s, found: %s", 
+            content_type, app_info ? "yes" : "no");
     if (!app_info) {
 #ifdef _WIN32
         // On Windows, if no default application is registered for directory content types,
@@ -326,15 +328,20 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
             for (uint32_t i = 0; i < files->len; ++i) {
                 GFile *file = g_ptr_array_index(files, i);
                 g_autofree char *uri = g_file_get_uri(file);
+                g_autofree char *path = g_file_get_path(file);
                 if (uri) {
+                    g_debug("[Windows] Attempting to open file with system default: %s (URI: %s, Content-Type: %s)", 
+                            path ? path : "unknown", uri, content_type);
                     g_autoptr(GError) error = NULL;
                     if (!g_app_info_launch_default_for_uri(uri, ctx->app_launch_context, &error)) {
-                        g_autofree char *path = g_file_get_path(file);
+                        g_debug("[Windows] Failed to open file with system default: %s", error ? error->message : "unknown error");
                         add_error_message_with_format(ctx->error_messages,
                                                       C_("Will be followed by the path of the file.",
                                                          "Error while opening file"),
                                                       path ? path : uri,
                                                       error->message);
+                    } else {
+                        g_debug("[Windows] Successfully launched system default for file: %s", path ? path : uri);
                     }
                 }
             }
@@ -354,10 +361,16 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
     FsearchFileUtilsLaunchUrisContext *launch_uris_ctx = g_new0(FsearchFileUtilsLaunchUrisContext, 1);
     launch_uris_ctx->app_info = g_steal_pointer(&app_info);
 
+    g_debug("[open_files] Using app_info for content type %s: %s", content_type, 
+            g_app_info_get_name(launch_uris_ctx->app_info));
+
     for (uint32_t i = 0; i < files->len; ++i) {
         GFile *file = g_ptr_array_index(files, i);
         char *uri = g_file_get_uri(file);
         if (uri) {
+            g_autofree char *path = g_file_get_path(file);
+            g_debug("[open_files] Adding file to launch queue: %s (URI: %s)", 
+                    path ? path : "unknown", uri);
             launch_uris_ctx->uris = g_list_append(launch_uris_ctx->uris, uri);
         }
     }

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -140,14 +140,17 @@ build_folder_open_cmd(const char *path, const char *path_full, const char *cmd) 
     
     // Also support legacy %p token for backward compatibility
     if (result && strstr(result, "%p")) {
+        g_autoptr(GRegex) legacy_regex = g_regex_new("%p", 0, 0, NULL);
+        if (legacy_regex) {
 #ifdef _WIN32
-        // On Windows, use the raw path without additional quoting since %p was already quoted in the template
-        g_autofree char *temp = g_strdup(result);
-        result = g_strreplace(temp, "%p", path_full, -1);
+            // On Windows, use the raw path without additional quoting since %p was already quoted in the template
+            g_autofree char *temp = g_steal_pointer(&result);
+            result = g_regex_replace_literal(legacy_regex, temp, -1, 0, path_full, 0, NULL);
 #else
-        g_autofree char *temp = g_strdup(result);
-        result = g_strreplace(temp, "%p", path_full_quoted, -1);
+            g_autofree char *temp = g_steal_pointer(&result);
+            result = g_regex_replace_literal(legacy_regex, temp, -1, 0, path_full_quoted, 0, NULL);
 #endif
+        }
     }
     
     return g_steal_pointer(&result);

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -241,8 +241,12 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
             if (!path) {
                 continue;
             }
-            #if defined(__MACH__) || defined(_WIN32)
+            #if defined(__MACH__)
             GAppInfo *desktop_app_info = g_app_info_create_from_commandline("/usr/bin/open", NULL, G_APP_INFO_CREATE_NONE, NULL);
+            #elif defined(_WIN32)
+            // On Windows, desktop files don't exist in the same way, so we just return NULL
+            // This will cause the fallback behavior to be used
+            GAppInfo *desktop_app_info = NULL;
             #else
             GDesktopAppInfo *desktop_app_info = g_desktop_app_info_new_from_filename(path);
             #endif

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -100,8 +100,15 @@ build_folder_open_cmd(const char *path, const char *path_full, const char *cmd) 
     if (!path || !path_full) {
         return NULL;
     }
+    
+#ifdef _WIN32
+    // On Windows, use simple double quotes for paths instead of shell quoting
+    g_autofree char *path_quoted = g_strdup_printf("\"%s\"", path);
+    g_autofree char *path_full_quoted = g_strdup_printf("\"%s\"", path_full);
+#else
     g_autofree char *path_quoted = g_shell_quote(path);
     g_autofree char *path_full_quoted = g_shell_quote(path_full);
+#endif
 
     // The following code is mostly based on the example code found here:
     // https://developer.gnome.org/glib/stable/glib-Perl-compatible-regular-expressions.html#g-regex-replace-eval
@@ -129,7 +136,21 @@ build_folder_open_cmd(const char *path, const char *path_full, const char *cmd) 
     // surrounded with {}
     g_autoptr(GRegex) reg = g_regex_new("{[\\w]+}", 0, 0, NULL);
     // Replace all the matched keywords
-    return g_regex_replace_eval(reg, cmd, -1, 0, 0, keyword_eval_cb, keywords, NULL);
+    g_autofree char *result = g_regex_replace_eval(reg, cmd, -1, 0, 0, keyword_eval_cb, keywords, NULL);
+    
+    // Also support legacy %p token for backward compatibility
+    if (result && strstr(result, "%p")) {
+#ifdef _WIN32
+        // On Windows, use the raw path without additional quoting since %p was already quoted in the template
+        g_autofree char *temp = g_strdup(result);
+        result = g_strreplace(temp, "%p", path_full, -1);
+#else
+        g_autofree char *temp = g_strdup(result);
+        result = g_strreplace(temp, "%p", path_full_quoted, -1);
+#endif
+    }
+    
+    return g_steal_pointer(&result);
 }
 
 static bool
@@ -271,12 +292,50 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
     if (!app_info) {
 #ifdef _WIN32
         // On Windows, if no default application is registered for directory content types,
-        // fall back to using explorer.exe directly
+        // we need to handle directories specially by launching explorer.exe with the path
         if (strcmp(content_type, "application/x-directory") == 0 || strcmp(content_type, "inode/directory") == 0) {
-            app_info = g_app_info_create_from_commandline("explorer.exe", "File Explorer", G_APP_INFO_CREATE_NONE, NULL);
-            if (app_info) {
-                g_debug("[Windows] Using explorer.exe fallback for directory content type: %s", content_type);
+            // For directories on Windows, we launch explorer.exe individually for each path
+            // instead of trying to batch them, since explorer.exe needs the specific path
+            for (uint32_t i = 0; i < files->len; ++i) {
+                GFile *file = g_ptr_array_index(files, i);
+                g_autofree char *path = g_file_get_path(file);
+                if (path) {
+                    g_autofree char *quoted_path = g_shell_quote(path);
+                    g_autofree char *command = g_strdup_printf("explorer.exe %s", quoted_path);
+                    g_autoptr(GError) error = NULL;
+                    if (!g_spawn_command_line_async(command, &error)) {
+                        add_error_message_with_format(ctx->error_messages,
+                                                      C_("Will be followed by the path of the folder.",
+                                                         "Error while opening folder"),
+                                                      path,
+                                                      error->message);
+                    } else {
+                        g_debug("[Windows] Launched explorer.exe for directory: %s", path);
+                    }
+                }
             }
+            return;
+        }
+        // For non-directory files on Windows, try to use the system default
+        // This should work for most file types including images
+        else {
+            // Use the system's default handler for this file type
+            for (uint32_t i = 0; i < files->len; ++i) {
+                GFile *file = g_ptr_array_index(files, i);
+                g_autofree char *uri = g_file_get_uri(file);
+                if (uri) {
+                    g_autoptr(GError) error = NULL;
+                    if (!g_app_info_launch_default_for_uri(uri, ctx->app_launch_context, &error)) {
+                        g_autofree char *path = g_file_get_path(file);
+                        add_error_message_with_format(ctx->error_messages,
+                                                      C_("Will be followed by the path of the file.",
+                                                         "Error while opening file"),
+                                                      path ? path : uri,
+                                                      error->message);
+                    }
+                }
+            }
+            return;
         }
 #endif
         if (!app_info) {

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -269,7 +269,7 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
             GAppInfo *desktop_app_info = g_app_info_create_from_commandline("/usr/bin/open", NULL, G_APP_INFO_CREATE_NONE, NULL);
             #elif defined(_WIN32)
             // On Windows, desktop files don't exist in the same way, so we just return NULL
-            // This will cause the fallback behavior to be used
+            // This will cause the fallback behavior to be used <- WRONG WRONG WRONG
             GAppInfo *desktop_app_info = NULL;
             #else
             GDesktopAppInfo *desktop_app_info = g_desktop_app_info_new_from_filename(path);
@@ -294,11 +294,10 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
     GAppInfo *app_info = g_app_info_get_default_for_type(content_type, FALSE);
     g_debug("[open_files] Looking for default app for content type: %s, found: %s", 
             content_type, app_info ? "yes" : "no");
-    if (!app_info) {
-#ifdef _WIN32
+	#ifdef _WIN32
+    //APP info is NOT FALSE HERE
         // On Windows, if no default application is registered for directory content types,
         // we need to handle directories specially by launching explorer.exe with the path
-        if (strcmp(content_type, "application/x-directory") == 0 || strcmp(content_type, "inode/directory") == 0) {
             // For directories on Windows, we launch explorer.exe individually for each path
             // instead of trying to batch them, since explorer.exe needs the specific path
             for (uint32_t i = 0; i < files->len; ++i) {
@@ -320,34 +319,11 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
                 }
             }
             return;
-        }
         // For non-directory files on Windows, try to use the system default
         // This should work for most file types including images
-        else {
-            // Use the system's default handler for this file type
-            for (uint32_t i = 0; i < files->len; ++i) {
-                GFile *file = g_ptr_array_index(files, i);
-                g_autofree char *uri = g_file_get_uri(file);
-                g_autofree char *path = g_file_get_path(file);
-                if (uri) {
-                    g_debug("[Windows] Attempting to open file with system default: %s (URI: %s, Content-Type: %s)", 
-                            path ? path : "unknown", uri, content_type);
-                    g_autoptr(GError) error = NULL;
-                    if (!g_app_info_launch_default_for_uri(uri, ctx->app_launch_context, &error)) {
-                        g_debug("[Windows] Failed to open file with system default: %s", error ? error->message : "unknown error");
-                        add_error_message_with_format(ctx->error_messages,
-                                                      C_("Will be followed by the path of the file.",
-                                                         "Error while opening file"),
-                                                      path ? path : uri,
-                                                      error->message);
-                    } else {
-                        g_debug("[Windows] Successfully launched system default for file: %s", path ? path : uri);
-                    }
-                }
-            }
-            return;
-        }
-#endif
+        #endif
+
+    if (!app_info) {
         if (!app_info) {
             add_error_message_with_format(ctx->error_messages,
                                           C_("Will be followed by the content type string.",
@@ -389,6 +365,7 @@ handle_callback(FsearchFileUtilsOpenCallback callback, gpointer callback_data, G
 
 static void
 handle_queued_uris(FsearchFileUtilsLaunchContext *launch_ctx) {
+	   printf("handle_quiued_uris\r\n");
     if (g_queue_is_empty(launch_ctx->launch_uris_ctx_queue)) {
         // All files were handled, either successfully or with errors
         handle_callback(launch_ctx->callback, launch_ctx->callback_data, launch_ctx->error_messages);
@@ -574,6 +551,7 @@ fsearch_file_utils_open_path_list(GList *paths,
 
 static bool
 fsearch_file_utils_open_path_with_command(const char *path, const char *cmd, GString *error_message) {
+	//ON WINDOWS THIS IS NOT OPENNG THE PARENT PATH BUT THE FILE ITSELF
     g_autoptr(GFile) file = g_file_new_for_path(path);
     g_autoptr(GFile) parent = g_file_get_parent(file);
     // If file has no parent it means it's the root directory.

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -569,7 +569,11 @@ fsearch_file_utils_open_path_with_command(const char *path, const char *cmd, GSt
     }
 
     const char *error_description = C_("Will be followed by the path of the folder.", "Error while opening folder");
+#ifdef _WIN32
+    g_autofree char *cmd_res = build_folder_open_cmd(parent_path, parent_path, cmd);
+#else
     g_autofree char *cmd_res = build_folder_open_cmd(path, path, cmd);
+#endif
     if (!cmd_res) {
         add_error_message_with_format(error_message, error_description, path, _("Failed to build open command"));
         return false;

--- a/src/fsearch_listview_popup.c
+++ b/src/fsearch_listview_popup.c
@@ -102,7 +102,11 @@ intersect_supported_appliations(gpointer key, gpointer value, gpointer user_data
     if (db_entry_get_type(entry) == DATABASE_ENTRY_TYPE_FOLDER) {
         // we already know the content type for folders, so we can use a slightly more
         // efficient and reliable path for them here
+#ifdef _WIN32
+        const char *dir_content_type = "application/x-directory";
+#else
         const char *dir_content_type = "inode/directory";
+#endif
         if (!g_hash_table_contains(ctx->content_types, dir_content_type)) {
             // no folder content type was added up until now, let's add one
             g_hash_table_add(ctx->content_types, g_strdup(dir_content_type));

--- a/src/fsearch_query_matchers.c
+++ b/src/fsearch_query_matchers.c
@@ -1,4 +1,8 @@
 #include "fsearch_query_matchers.h"
+
+#ifdef _WIN32
+#include "win32_compat.h"
+#endif
 #include "fsearch_query_node.h"
 #include <string.h>
 

--- a/src/fsearch_query_node.c
+++ b/src/fsearch_query_node.c
@@ -7,6 +7,7 @@
 #include "fsearch_string_utils.h"
 #include "fsearch_utf.h"
 #include <glib.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
 
@@ -52,17 +53,17 @@ static char *
 get_needle_description_for_comparison_type(int64_t start, int64_t end, FsearchQueryNodeComparison comp_type) {
     switch (comp_type) {
     case FSEARCH_QUERY_NODE_COMPARISON_EQUAL:
-        return g_strdup_printf("=%lld", (long long)start);
+        return g_strdup_printf("=%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_GREATER_EQ:
-        return g_strdup_printf(">=%lld", (long long)start);
+        return g_strdup_printf(">=%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_GREATER:
-        return g_strdup_printf(">%lld", (long long)start);
+        return g_strdup_printf(">%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_SMALLER_EQ:
-        return g_strdup_printf("<=%lld", (long long)start);
+        return g_strdup_printf("<=%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_SMALLER:
-        return g_strdup_printf("<%lld", (long long)start);
+        return g_strdup_printf("<%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_RANGE:
-        return g_strdup_printf("%lld..%lld", (long long)start, (long long)end);
+        return g_strdup_printf("%" PRId64 "..%" PRId64, start, end);
     default:
         return g_strdup("invalid");
     }

--- a/src/fsearch_query_node.c
+++ b/src/fsearch_query_node.c
@@ -52,17 +52,17 @@ static char *
 get_needle_description_for_comparison_type(int64_t start, int64_t end, FsearchQueryNodeComparison comp_type) {
     switch (comp_type) {
     case FSEARCH_QUERY_NODE_COMPARISON_EQUAL:
-        return g_strdup_printf("=%ld", start);
+        return g_strdup_printf("=%lld", (long long)start);
     case FSEARCH_QUERY_NODE_COMPARISON_GREATER_EQ:
-        return g_strdup_printf(">=%ld", start);
+        return g_strdup_printf(">=%lld", (long long)start);
     case FSEARCH_QUERY_NODE_COMPARISON_GREATER:
-        return g_strdup_printf(">%ld", start);
+        return g_strdup_printf(">%lld", (long long)start);
     case FSEARCH_QUERY_NODE_COMPARISON_SMALLER_EQ:
-        return g_strdup_printf("<=%ld", start);
+        return g_strdup_printf("<=%lld", (long long)start);
     case FSEARCH_QUERY_NODE_COMPARISON_SMALLER:
-        return g_strdup_printf("<%ld", start);
+        return g_strdup_printf("<%lld", (long long)start);
     case FSEARCH_QUERY_NODE_COMPARISON_RANGE:
-        return g_strdup_printf("%ld..%ld", start, end);
+        return g_strdup_printf("%lld..%lld", (long long)start, (long long)end);
     default:
         return g_strdup("invalid");
     }

--- a/src/fsearch_result_view.c
+++ b/src/fsearch_result_view.c
@@ -2,6 +2,10 @@
 
 #include "fsearch_result_view.h"
 
+#ifdef _WIN32
+#include "win32_compat.h"
+#endif
+
 #include "fsearch.h"
 #include "fsearch_config.h"
 #include "fsearch_file_utils.h"

--- a/src/fsearch_time_utils.c
+++ b/src/fsearch_time_utils.c
@@ -1,5 +1,9 @@
 #include "fsearch_time_utils.h"
 
+#ifdef _WIN32
+#include "win32_compat.h"
+#endif
+
 #include <glib.h>
 #include <stdint.h>
 #include <time.h>

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -20,10 +20,8 @@
 #include <config.h>
 #endif
 
-#ifndef __MACH__
-#ifndef _WIN32
+#if !defined(__MACH__) && !defined(_WIN32)
 #include <gio/gdesktopappinfo.h>
-#endif
 #endif
 
 #include <glib/gi18n.h>
@@ -468,12 +466,10 @@ fsearch_window_action_open_with(GSimpleAction *action, GVariant *variant, gpoint
     }
     #ifdef __MACH__
     g_autoptr(GAppInfo) app_info = NULL;
-    #else
-#ifndef _WIN32
-    g_autoptr(GDesktopAppInfo) app_info = g_desktop_app_info_new(app_id);
-#else
+    #elif defined(_WIN32)
     g_autoptr(GAppInfo) app_info = g_app_info_create_from_commandline(app_id, NULL, G_APP_INFO_CREATE_NONE, NULL);
-#endif
+    #else
+    g_autoptr(GDesktopAppInfo) app_info = g_desktop_app_info_new(app_id);
     #endif
     
     if (!app_info) {

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -21,7 +21,9 @@
 #endif
 
 #ifndef __MACH__
+#ifndef _WIN32
 #include <gio/gdesktopappinfo.h>
+#endif
 #endif
 
 #include <glib/gi18n.h>
@@ -467,7 +469,11 @@ fsearch_window_action_open_with(GSimpleAction *action, GVariant *variant, gpoint
     #ifdef __MACH__
     g_autoptr(GAppInfo) app_info = NULL;
     #else
+#ifndef _WIN32
     g_autoptr(GDesktopAppInfo) app_info = g_desktop_app_info_new(app_id);
+#else
+    g_autoptr(GAppInfo) app_info = g_app_info_create_from_commandline(app_id, NULL, G_APP_INFO_CREATE_NONE, NULL);
+#endif
     #endif
     
     if (!app_info) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -56,11 +56,13 @@ libfsearch_sources = [
 
 if build_machine.system()=='darwin'
     libfsearch_sources+=['strverscmp.c']
+elif host_machine.system()=='windows'
+    libfsearch_sources+=['strverscmp.c', 'win32_compat.c']
 endif
 
 fsearch_deps = [
     cc.find_library('m', required: true),
-    dependency('gio-unix-2.0', version: '>= 2.50'),
+    dependency(host_machine.system() == 'windows' ? 'gio-windows-2.0' : 'gio-unix-2.0', version: '>= 2.50'),
     dependency('gtk+-3.0', version: '>= 3.18'),
     dependency('libpcre2-8', version: '>= 10.21'),
     dependency('icu-uc', version: '>= 3.8'),

--- a/src/win32_compat.c
+++ b/src/win32_compat.c
@@ -1,0 +1,247 @@
+#ifdef _WIN32
+
+#include "win32_compat.h"
+#include <windows.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <glib.h>
+
+// Windows implementation of flock
+int win32_flock(int fd, int operation) {
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return -1;
+    }
+    
+    OVERLAPPED overlapped = {0};
+    DWORD flags = 0;
+    
+    if (operation & LOCK_EX) {
+        flags = LOCKFILE_EXCLUSIVE_LOCK;
+    }
+    if (operation & LOCK_NB) {
+        flags |= LOCKFILE_FAIL_IMMEDIATELY;
+    }
+    
+    if (LockFileEx(handle, flags, 0, MAXDWORD, MAXDWORD, &overlapped)) {
+        return 0;
+    }
+    return -1;
+}
+
+// Windows implementation of strcasestr
+char *win32_strcasestr(const char *haystack, const char *needle) {
+    if (!haystack || !needle) {
+        return NULL;
+    }
+    
+    size_t needle_len = strlen(needle);
+    if (needle_len == 0) {
+        return (char *)haystack;
+    }
+    
+    for (const char *h = haystack; *h; h++) {
+        if (g_ascii_strncasecmp(h, needle, needle_len) == 0) {
+            return (char *)h;
+        }
+    }
+    return NULL;
+}
+
+// Windows implementation of lstat (just use stat since Windows doesn't have symlinks in the same way)
+int win32_lstat(const char *path, struct stat *buf) {
+    return stat(path, buf);
+}
+
+// Simple fnmatch implementation for Windows
+static int match_pattern(const char *pattern, const char *string, int flags) {
+    const char *p = pattern;
+    const char *s = string;
+    
+    while (*p && *s) {
+        if (*p == '*') {
+            // Handle wildcard
+            p++;
+            if (*p == '\0') {
+                return 0; // Match
+            }
+            
+            while (*s) {
+                if (match_pattern(p, s, flags) == 0) {
+                    return 0;
+                }
+                s++;
+            }
+            return FNM_NOMATCH;
+        } else if (*p == '?') {
+            // Match any single character
+            p++;
+            s++;
+        } else {
+            // Literal character match
+            int match;
+            if (flags & FNM_PATHNAME && (*p == '/' || *p == '\\')) {
+                // Handle path separators
+                match = (*s == '/' || *s == '\\');
+            } else {
+                // Case-insensitive comparison on Windows
+                match = (tolower(*p) == tolower(*s));
+            }
+            
+            if (!match) {
+                return FNM_NOMATCH;
+            }
+            p++;
+            s++;
+        }
+    }
+    
+    // Handle remaining pattern characters
+    while (*p == '*') {
+        p++;
+    }
+    
+    return (*p == '\0' && *s == '\0') ? 0 : FNM_NOMATCH;
+}
+
+int win32_fnmatch(const char *pattern, const char *string, int flags) {
+    if (!pattern || !string) {
+        return FNM_NOMATCH;
+    }
+    
+    return match_pattern(pattern, string, flags);
+}
+
+// Simple strptime implementation for Windows
+char *win32_strptime(const char *s, const char *format, struct tm *tm) {
+    // Very basic implementation - only handles common formats
+    // This is a simplified version that handles basic ISO date formats
+    
+    if (!s || !format || !tm) {
+        return NULL;
+    }
+    
+    // Clear the tm structure
+    memset(tm, 0, sizeof(struct tm));
+    
+    // Handle common ISO date formats
+    if (strcmp(format, "%Y-%m-%d") == 0) {
+        int year, month, day;
+        if (sscanf(s, "%d-%d-%d", &year, &month, &day) == 3) {
+            tm->tm_year = year - 1900;
+            tm->tm_mon = month - 1;
+            tm->tm_mday = day;
+            return (char*)(s + 10); // Return pointer after parsed part
+        }
+    }
+    else if (strcmp(format, "%Y-%m-%d %H:%M:%S") == 0) {
+        int year, month, day, hour, min, sec;
+        if (sscanf(s, "%d-%d-%d %d:%d:%d", &year, &month, &day, &hour, &min, &sec) == 6) {
+            tm->tm_year = year - 1900;
+            tm->tm_mon = month - 1;
+            tm->tm_mday = day;
+            tm->tm_hour = hour;
+            tm->tm_min = min;
+            tm->tm_sec = sec;
+            return (char*)(s + 19); // Return pointer after parsed part
+        }
+    }
+    
+    return NULL; // Format not supported or parsing failed
+}
+
+// Windows directory reading implementations
+DIR *win32_opendir(const char *dirname) {
+    DIR *dirp = malloc(sizeof(DIR));
+    if (!dirp) {
+        return NULL;
+    }
+    
+    char search_path[MAX_PATH];
+    snprintf(search_path, sizeof(search_path), "%s\\*", dirname);
+    
+    dirp->handle = FindFirstFileA(search_path, &dirp->find_data);
+    if (dirp->handle == INVALID_HANDLE_VALUE) {
+        free(dirp);
+        return NULL;
+    }
+    
+    dirp->first = 1;
+    return dirp;
+}
+
+struct dirent *win32_readdir(DIR *dirp) {
+    if (!dirp || dirp->handle == INVALID_HANDLE_VALUE) {
+        return NULL;
+    }
+    
+    if (dirp->first) {
+        dirp->first = 0;
+    } else {
+        if (!FindNextFileA(dirp->handle, &dirp->find_data)) {
+            return NULL;
+        }
+    }
+    
+    strncpy(dirp->entry.d_name, dirp->find_data.cFileName, sizeof(dirp->entry.d_name) - 1);
+    dirp->entry.d_name[sizeof(dirp->entry.d_name) - 1] = '\0';
+    
+    return &dirp->entry;
+}
+
+int win32_closedir(DIR *dirp) {
+    if (!dirp) {
+        return -1;
+    }
+    
+    if (dirp->handle != INVALID_HANDLE_VALUE) {
+        FindClose(dirp->handle);
+    }
+    free(dirp);
+    return 0;
+}
+
+int win32_dirfd(DIR *dirp) {
+    // Windows doesn't have file descriptors for directories like Unix
+    // Return a dummy value - this might need adjustment based on usage
+    return -1;
+}
+
+int win32_fstatat(int dirfd, const char *pathname, struct stat *buf, int flags) {
+    // Since Windows doesn't have directory file descriptors like Unix,
+    // we need to get the current directory path and construct the full path.
+    // This is a limitation of our Windows compatibility layer.
+    
+    // If pathname is already absolute, use it directly
+    if (pathname && (pathname[0] == '/' || pathname[0] == '\\' ||
+                    (pathname[0] && pathname[1] == ':'))) {
+        return stat(pathname, buf);
+    }
+    
+    // For relative paths, we need to get the current working directory
+    // and construct the full path
+    char full_path[MAX_PATH];
+    if (GetCurrentDirectoryA(sizeof(full_path), full_path) == 0) {
+        return -1;
+    }
+    
+    // Append path separator if needed
+    size_t len = strlen(full_path);
+    if (len > 0 && full_path[len-1] != '\\' && full_path[len-1] != '/') {
+        strcat(full_path, "\\");
+    }
+    
+    // Append the filename
+    if (strlen(full_path) + strlen(pathname) >= MAX_PATH) {
+        return -1; // Path too long
+    }
+    strcat(full_path, pathname);
+    
+    printf("[DEBUG] fstatat: pathname='%s', full_path='%s'\n", pathname, full_path);
+    
+    return stat(full_path, buf);
+}
+
+#endif // _WIN32

--- a/src/win32_compat.c
+++ b/src/win32_compat.c
@@ -160,7 +160,7 @@ DIR *win32_opendir(const char *dirname) {
     
     // Check if dirname is too long to safely append "\\*" and null terminator
     // We need: strlen(dirname) + strlen("\\*") + 1 (null terminator) <= MAX_PATH
-    if (strlen(dirname) + 2 >= MAX_PATH) {
+    if (strlen(dirname) + 3 > MAX_PATH) {
         // Handle error: dirname too long
         return NULL;
     }

--- a/src/win32_compat.c
+++ b/src/win32_compat.c
@@ -241,14 +241,17 @@ int win32_fstatat(int dirfd, const char *pathname, struct stat *buf, int flags) 
     // Append path separator if needed
     size_t len = strlen(full_path);
     if (len > 0 && full_path[len-1] != '\\' && full_path[len-1] != '/') {
-        strcat(full_path, "\\");
+        if (len + 1 >= MAX_PATH) { // Ensure space for backslash and null terminator
+            return -1; // Path too long
+        }
+        strncat(full_path, "\\", MAX_PATH - len - 1);
     }
     
     // Append the filename
-    if (strlen(full_path) + strlen(pathname) >= MAX_PATH) {
+    if (len + strlen(pathname) >= MAX_PATH) { // Ensure total length does not exceed MAX_PATH
         return -1; // Path too long
     }
-    strcat(full_path, pathname);
+    strncat(full_path, pathname, MAX_PATH - len - 1);
     
     // printf("[DEBUG] fstatat: pathname='%s', full_path='%s'\n", pathname, full_path);
     

--- a/src/win32_compat.c
+++ b/src/win32_compat.c
@@ -154,6 +154,17 @@ char *win32_strptime(const char *s, const char *format, struct tm *tm) {
 
 // Windows directory reading implementations
 DIR *win32_opendir(const char *dirname) {
+    if (!dirname) {
+        return NULL;
+    }
+    
+    // Check if dirname is too long to safely append "\\*" and null terminator
+    // We need: strlen(dirname) + strlen("\\*") + 1 (null terminator) <= MAX_PATH
+    if (strlen(dirname) + 2 >= MAX_PATH) {
+        // Handle error: dirname too long
+        return NULL;
+    }
+    
     DIR *dirp = malloc(sizeof(DIR));
     if (!dirp) {
         return NULL;

--- a/src/win32_compat.c
+++ b/src/win32_compat.c
@@ -50,8 +50,21 @@ char *win32_strcasestr(const char *haystack, const char *needle) {
     return NULL;
 }
 
-// Windows implementation of lstat (just use stat since Windows doesn't have symlinks in the same way)
+// Windows implementation of lstat with Unicode support
 int win32_lstat(const char *path, struct stat *buf) {
+    if (!path || !buf) {
+        return -1;
+    }
+    
+    // Try Unicode version first for better international character support
+    wchar_t *wpath = win32_utf8_to_wchar(path);
+    if (wpath) {
+        int result = _wstat64(wpath, (struct _stat64*)buf);
+        win32_free_wchar(wpath);
+        return result;
+    }
+    
+    // Fallback to ANSI version
     return stat(path, buf);
 }
 
@@ -152,7 +165,146 @@ char *win32_strptime(const char *s, const char *format, struct tm *tm) {
     return NULL; // Format not supported or parsing failed
 }
 
-// Windows directory reading implementations
+// Wide string conversion utilities for Unicode support
+wchar_t *win32_utf8_to_wchar(const char *utf8_str) {
+    if (!utf8_str) {
+        return NULL;
+    }
+    
+    // Calculate required buffer size
+    int wchar_len = MultiByteToWideChar(CP_UTF8, 0, utf8_str, -1, NULL, 0);
+    if (wchar_len <= 0) {
+        return NULL;
+    }
+    
+    // Allocate buffer and convert
+    wchar_t *wchar_str = malloc(wchar_len * sizeof(wchar_t));
+    if (!wchar_str) {
+        return NULL;
+    }
+    
+    if (MultiByteToWideChar(CP_UTF8, 0, utf8_str, -1, wchar_str, wchar_len) == 0) {
+        free(wchar_str);
+        return NULL;
+    }
+    
+    return wchar_str;
+}
+
+char *win32_wchar_to_utf8(const wchar_t *wchar_str) {
+    if (!wchar_str) {
+        return NULL;
+    }
+    
+    // Calculate required buffer size
+    int utf8_len = WideCharToMultiByte(CP_UTF8, 0, wchar_str, -1, NULL, 0, NULL, NULL);
+    if (utf8_len <= 0) {
+        return NULL;
+    }
+    
+    // Allocate buffer and convert
+    char *utf8_str = malloc(utf8_len);
+    if (!utf8_str) {
+        return NULL;
+    }
+    
+    if (WideCharToMultiByte(CP_UTF8, 0, wchar_str, -1, utf8_str, utf8_len, NULL, NULL) == 0) {
+        free(utf8_str);
+        return NULL;
+    }
+    
+    return utf8_str;
+}
+
+void win32_free_wchar(wchar_t *wchar_str) {
+    if (wchar_str) {
+        free(wchar_str);
+    }
+}
+
+void win32_free_utf8(char *utf8_str) {
+    if (utf8_str) {
+        free(utf8_str);
+    }
+}
+
+// Unicode-aware directory opening
+DIR *win32_opendir_unicode(const char *dirname) {
+    if (!dirname) {
+        return NULL;
+    }
+    
+    // Convert UTF-8 dirname to wide string
+    wchar_t *wdirname = win32_utf8_to_wchar(dirname);
+    if (!wdirname) {
+        // Fallback to ANSI version
+        return win32_opendir(dirname);
+    }
+    
+    // Check if dirname is too long to safely append L"\\*" and null terminator
+    size_t wdirname_len = wcslen(wdirname);
+    if (wdirname_len + 2 >= MAX_PATH) {
+        win32_free_wchar(wdirname);
+        return NULL;
+    }
+    
+    DIR *dirp = malloc(sizeof(DIR));
+    if (!dirp) {
+        win32_free_wchar(wdirname);
+        return NULL;
+    }
+    
+    // Construct search pattern
+    wchar_t wsearch_path[MAX_PATH];
+    swprintf(wsearch_path, MAX_PATH, L"%ls\\*", wdirname);
+    win32_free_wchar(wdirname);
+    
+    // Use Unicode version of FindFirstFile
+    dirp->handle = FindFirstFileW(wsearch_path, (WIN32_FIND_DATAW*)&dirp->find_data);
+    if (dirp->handle == INVALID_HANDLE_VALUE) {
+        free(dirp);
+        return NULL;
+    }
+    
+    dirp->first = 1;
+    return dirp;
+}
+
+struct dirent *win32_readdir_unicode(DIR *dirp) {
+    if (!dirp || dirp->handle == INVALID_HANDLE_VALUE) {
+        return NULL;
+    }
+    
+    WIN32_FIND_DATAW *find_data = (WIN32_FIND_DATAW*)&dirp->find_data;
+    
+    if (dirp->first) {
+        dirp->first = 0;
+    } else {
+        if (!FindNextFileW(dirp->handle, find_data)) {
+            return NULL;
+        }
+    }
+    
+    // Convert wide string filename to UTF-8
+    char *utf8_name = win32_wchar_to_utf8(find_data->cFileName);
+    if (utf8_name) {
+        strncpy(dirp->entry.d_name, utf8_name, sizeof(dirp->entry.d_name) - 1);
+        dirp->entry.d_name[sizeof(dirp->entry.d_name) - 1] = '\0';
+        win32_free_utf8(utf8_name);
+    } else {
+        // Fallback: truncate wide string to ASCII
+        size_t len = wcstombs(dirp->entry.d_name, find_data->cFileName, sizeof(dirp->entry.d_name) - 1);
+        if (len == (size_t)-1) {
+            dirp->entry.d_name[0] = '\0';
+        } else {
+            dirp->entry.d_name[len] = '\0';
+        }
+    }
+    
+    return &dirp->entry;
+}
+
+// Windows directory reading implementations (ANSI versions for backward compatibility)
 DIR *win32_opendir(const char *dirname) {
     if (!dirname) {
         return NULL;
@@ -225,37 +377,69 @@ int win32_fstatat(int dirfd, const char *pathname, struct stat *buf, int flags) 
     // we need to get the current directory path and construct the full path.
     // This is a limitation of our Windows compatibility layer.
     
-    // If pathname is already absolute, use it directly
-    if (pathname && (pathname[0] == '/' || pathname[0] == '\\' ||
-                    (pathname[0] && pathname[1] == ':'))) {
-        return stat(pathname, buf);
-    }
-    
-    // For relative paths, we need to get the current working directory
-    // and construct the full path
-    char full_path[MAX_PATH];
-    if (GetCurrentDirectoryA(sizeof(full_path), full_path) == 0) {
+    if (!pathname || !buf) {
         return -1;
     }
     
-    // Append path separator if needed
-    size_t len = strlen(full_path);
-    if (len > 0 && full_path[len-1] != '\\' && full_path[len-1] != '/') {
-        if (len + 1 >= MAX_PATH) { // Ensure space for backslash and null terminator
-            return -1; // Path too long
+    // If pathname is already absolute, use Unicode lstat directly
+    if (pathname[0] == '/' || pathname[0] == '\\' ||
+        (pathname[0] && pathname[1] == ':')) {
+        return win32_lstat(pathname, buf);
+    }
+    
+    // For relative paths, we need to get the current working directory
+    // and construct the full path using Unicode functions
+    wchar_t wfull_path[MAX_PATH];
+    if (GetCurrentDirectoryW(MAX_PATH, wfull_path) == 0) {
+        return -1;
+    }
+    
+    // Convert pathname to wide string
+    wchar_t *wpathname = win32_utf8_to_wchar(pathname);
+    if (!wpathname) {
+        // Fallback to ANSI version
+        char full_path[MAX_PATH];
+        if (GetCurrentDirectoryA(sizeof(full_path), full_path) == 0) {
+            return -1;
         }
-        strncat(full_path, "\\", MAX_PATH - len - 1);
+        
+        size_t len = strlen(full_path);
+        if (len > 0 && full_path[len-1] != '\\' && full_path[len-1] != '/') {
+            if (len + 1 >= MAX_PATH) {
+                return -1;
+            }
+            strncat(full_path, "\\", MAX_PATH - len - 1);
+        }
+        
+        if (len + strlen(pathname) >= MAX_PATH) {
+            return -1;
+        }
+        strncat(full_path, pathname, MAX_PATH - len - 1);
+        
+        return stat(full_path, buf);
+    }
+    
+    // Append path separator if needed
+    size_t wlen = wcslen(wfull_path);
+    if (wlen > 0 && wfull_path[wlen-1] != L'\\' && wfull_path[wlen-1] != L'/') {
+        if (wlen + 1 >= MAX_PATH) {
+            win32_free_wchar(wpathname);
+            return -1;
+        }
+        wcscat(wfull_path, L"\\");
+        wlen++;
     }
     
     // Append the filename
-    if (len + strlen(pathname) >= MAX_PATH) { // Ensure total length does not exceed MAX_PATH
-        return -1; // Path too long
+    if (wlen + wcslen(wpathname) >= MAX_PATH) {
+        win32_free_wchar(wpathname);
+        return -1;
     }
-    strncat(full_path, pathname, MAX_PATH - len - 1);
+    wcscat(wfull_path, wpathname);
+    win32_free_wchar(wpathname);
     
-    // printf("[DEBUG] fstatat: pathname='%s', full_path='%s'\n", pathname, full_path);
-    
-    return stat(full_path, buf);
+    // Use Unicode stat
+    return _wstat64(wfull_path, (struct _stat64*)buf);
 }
 
 #endif // _WIN32

--- a/src/win32_compat.c
+++ b/src/win32_compat.c
@@ -239,7 +239,7 @@ int win32_fstatat(int dirfd, const char *pathname, struct stat *buf, int flags) 
     }
     strcat(full_path, pathname);
     
-    printf("[DEBUG] fstatat: pathname='%s', full_path='%s'\n", pathname, full_path);
+    // printf("[DEBUG] fstatat: pathname='%s', full_path='%s'\n", pathname, full_path);
     
     return stat(full_path, buf);
 }

--- a/src/win32_compat.h
+++ b/src/win32_compat.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <io.h>
+#include <direct.h>
+#include <fcntl.h>
+#include <string.h>
+#include <ctype.h>
+#include <time.h>
+#include <stdio.h>
+
+// Define POSIX types that are missing on Windows
+#ifndef off_t
+#ifdef _WIN64
+typedef __int64 off_t;
+#else
+typedef long off_t;
+#endif
+#endif
+
+// Define missing constants
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
+
+#ifndef S_ISREG
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#endif
+
+// Windows doesn't have these POSIX file locking constants
+#ifndef LOCK_EX
+#define LOCK_EX 2
+#endif
+
+#ifndef LOCK_NB
+#define LOCK_NB 4
+#endif
+
+// Directory separator compatibility
+#ifndef G_DIR_SEPARATOR
+#define G_DIR_SEPARATOR '\\'
+#endif
+
+#ifndef G_DIR_SEPARATOR_S
+#define G_DIR_SEPARATOR_S "\\"
+#endif
+
+// Function declarations for Windows compatibility
+int win32_flock(int fd, int operation);
+char *win32_strcasestr(const char *haystack, const char *needle);
+int win32_lstat(const char *path, struct stat *buf);
+int win32_fnmatch(const char *pattern, const char *string, int flags);
+char *win32_strptime(const char *s, const char *format, struct tm *tm);
+
+// Map POSIX functions to Windows implementations
+#define flock(fd, op) win32_flock(fd, op)
+#define strcasestr(h, n) win32_strcasestr(h, n)
+#define lstat(p, b) win32_lstat(p, b)
+#define fnmatch(p, s, f) win32_fnmatch(p, s, f)
+#define strptime(s, f, tm) win32_strptime(s, f, tm)
+
+// Directory reading compatibility
+#include <windows.h>
+
+// POSIX dirent structure for Windows
+struct dirent {
+    char d_name[260]; // MAX_PATH
+};
+
+typedef struct {
+    HANDLE handle;
+    WIN32_FIND_DATAA find_data;
+    struct dirent entry;
+    int first;
+} DIR;
+
+DIR *win32_opendir(const char *dirname);
+struct dirent *win32_readdir(DIR *dirp);
+int win32_closedir(DIR *dirp);
+int win32_dirfd(DIR *dirp);
+
+#define opendir(d) win32_opendir(d)
+#define readdir(d) win32_readdir(d)
+#define dirfd(d) win32_dirfd(d)
+
+// For g_clear_pointer compatibility, we need a function that matches the signature
+static inline void win32_closedir_clear(DIR *dirp) {
+    win32_closedir(dirp);
+}
+#define closedir win32_closedir_clear
+
+// File status functions
+#define AT_SYMLINK_NOFOLLOW 0x100
+int win32_fstatat(int dirfd, const char *pathname, struct stat *buf, int flags);
+#define fstatat(d, p, b, f) win32_fstatat(d, p, b, f)
+
+// fnmatch flags
+#ifndef FNM_NOMATCH
+#define FNM_NOMATCH 1
+#endif
+
+#ifndef FNM_PATHNAME
+#define FNM_PATHNAME (1 << 0)
+#endif
+
+#ifndef FNM_NOESCAPE
+#define FNM_NOESCAPE (1 << 1)
+#endif
+
+#ifndef FNM_PERIOD
+#define FNM_PERIOD (1 << 2)
+#endif
+
+#endif // _WIN32

--- a/src/win32_compat.h
+++ b/src/win32_compat.h
@@ -63,9 +63,6 @@ char *win32_strptime(const char *s, const char *format, struct tm *tm);
 #define fnmatch(p, s, f) win32_fnmatch(p, s, f)
 #define strptime(s, f, tm) win32_strptime(s, f, tm)
 
-// Directory reading compatibility
-#include <windows.h>
-
 // POSIX dirent structure for Windows
 struct dirent {
     char d_name[260]; // MAX_PATH

--- a/src/win32_compat.h
+++ b/src/win32_compat.h
@@ -80,8 +80,9 @@ struct dirent *win32_readdir(DIR *dirp);
 int win32_closedir(DIR *dirp);
 int win32_dirfd(DIR *dirp);
 
-#define opendir(d) win32_opendir(d)
-#define readdir(d) win32_readdir(d)
+// Use Unicode-aware versions by default for better international character support
+#define opendir(d) win32_opendir_unicode(d)
+#define readdir(d) win32_readdir_unicode(d)
 #define dirfd(d) win32_dirfd(d)
 
 // For g_clear_pointer compatibility, we need a function that matches the signature
@@ -94,6 +95,26 @@ static inline void win32_closedir_clear(DIR *dirp) {
 #define AT_SYMLINK_NOFOLLOW 0x100
 int win32_fstatat(int dirfd, const char *pathname, struct stat *buf, int flags);
 #define fstatat(d, p, b, f) win32_fstatat(d, p, b, f)
+
+// Wide string conversion utilities for Unicode support
+wchar_t *win32_utf8_to_wchar(const char *utf8_str);
+char *win32_wchar_to_utf8(const wchar_t *wchar_str);
+void win32_free_wchar(wchar_t *wchar_str);
+void win32_free_utf8(char *utf8_str);
+
+// Enhanced DIR structure with Unicode support
+typedef struct {
+    HANDLE handle;
+    WIN32_FIND_DATAW find_data_w;  // Unicode version
+    WIN32_FIND_DATAA find_data_a;  // ANSI version (for backward compatibility)
+    struct dirent entry;
+    int first;
+    int use_unicode;
+} DIR_UNICODE;
+
+// Unicode-aware directory functions
+DIR *win32_opendir_unicode(const char *dirname);
+struct dirent *win32_readdir_unicode(DIR *dirp);
 
 // fnmatch flags
 #ifndef FNM_NOMATCH


### PR DESCRIPTION
This pull request introduces a series of changes to improve compatibility with Windows for the FSearch application. The most significant updates include the addition of a Windows compatibility layer (`win32_compat.c`), adjustments to platform-specific code paths, and fallback mechanisms for Windows-specific behaviors.

### Windows Compatibility Layer
* Added a new file `win32_compat.c` to provide Windows-specific implementations for Unix-like functions such as `flock`, `fnmatch`, `lstat`, `strptime`, and directory handling functions like `opendir` and `readdir`. This ensures compatibility with Windows APIs.

### Platform-Specific Adjustments
* Introduced conditional compilation (`#ifdef _WIN32`) in multiple files to handle platform-specific differences, such as using `explorer.exe` for opening directories, handling Windows-style paths, and converting Unix-style content types like `inode/directory` to Windows-compatible types. [[1]](diffhunk://#diff-83d5b1cbe57f2ff0bb3ddb46d3833b90771c104a67ea845633f8e652cdb7853eR251-R255) [[2]](diffhunk://#diff-d1bd41820e45a6cae209fcb8287fb9b4da2915279f7e56c1211b41bbe91e5226R1260-R1271) [[3]](diffhunk://#diff-de4a4283e3d996d2e4868ed7a73c1f612c12aab586a6e6a411f4397b325d8167R670-R678)
* Updated the Meson build configuration to include `win32_compat.c` and adjust dependencies for Windows builds (e.g., `gio-windows-2.0` instead of `gio-unix-2.0`).

### Code Path Modifications
* Replaced Unix-specific functions with Windows-compatible alternatives where necessary, such as using `stat` instead of `fstatat` on Windows and implementing fallback logic for missing default applications in Windows. [[1]](diffhunk://#diff-d1bd41820e45a6cae209fcb8287fb9b4da2915279f7e56c1211b41bbe91e5226R1260-R1271) [[2]](diffhunk://#diff-de4a4283e3d996d2e4868ed7a73c1f612c12aab586a6e6a411f4397b325d8167R286)
* Adjusted string formatting to use `long long` for compatibility with Windows compilers.

### Enhanced Debugging and Fallbacks
* Added debug messages and fallback mechanisms, such as using `explorer.exe` when no default application is registered for directories on Windows.
* Introduced basic implementations for missing functions like `strptime` and `fnmatch` to handle common use cases on Windows.

### Code Refactoring for Cross-Platform Support
* Consolidated platform-specific logic into preprocessor directives to simplify the codebase and ensure maintainability. This includes adjustments in `fsearch_config.c`, `fsearch_database.c`, and other core files. [[1]](diffhunk://#diff-d1bd41820e45a6cae209fcb8287fb9b4da2915279f7e56c1211b41bbe91e5226R1322-R1327) [[2]](diffhunk://#diff-2edbc0ff66c4b9a7616f855c771c0cadc1bfb9d26c21a343b85ab0df2434cee8R472-R476)

These changes collectively enhance FSearch's portability and usability on Windows while maintaining functionality on other platforms.