### PR TITLE
Fix critical Win32 buffer overflow and compatibility issues

### DIFF
--- a/src/fsearch_config.c
+++ b/src/fsearch_config.c
@@ -248,7 +248,11 @@ config_load(FsearchConfig *config) {
         config->show_dialog_failed_opening = config_load_boolean(key_file, "Dialogs", "show_dialog_failed_opening", true);
 
         // Applications
+#ifdef _WIN32
+        config->folder_open_cmd = config_load_string(key_file, "Applications", "folder_open_cmd", "explorer.exe \"{path_full_raw}\"");
+#else
         config->folder_open_cmd = config_load_string(key_file, "Applications", "folder_open_cmd", NULL);
+#endif
 
         // Window
         config->restore_window_size = config_load_boolean(key_file, "Interface", "restore_window_size", false);

--- a/src/fsearch_database.c
+++ b/src/fsearch_database.c
@@ -1295,9 +1295,6 @@ db_folder_scan_recursive(DatabaseWalkContext *walk_context, FsearchDatabaseEntry
         else {
             FsearchDatabaseEntry *file_entry = fsearch_memory_pool_malloc(db->file_pool);
             db_entry_set_name(file_entry, dent->d_name);
-#ifdef _WIN32
-           // printf("[DEBUG] File: %s, Size from stat: %lld bytes\n", dent->d_name, (long long)st.st_size);
-#endif
             db_entry_set_size(file_entry, st.st_size);
             db_entry_set_mtime(file_entry, st.st_mtime);
             db_entry_set_type(file_entry, DATABASE_ENTRY_TYPE_FILE);

--- a/src/fsearch_database_entry.c
+++ b/src/fsearch_database_entry.c
@@ -1,4 +1,8 @@
 #include "fsearch_database_entry.h"
+
+#ifdef _WIN32
+#include "win32_compat.h"
+#endif
 #include "fsearch_file_utils.h"
 #include "fsearch_string_utils.h"
 
@@ -6,7 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef __MACH__
+#if defined(__MACH__) || defined(_WIN32)
 #include "strverscmp.h"
 #endif
 

--- a/src/fsearch_database_entry.h
+++ b/src/fsearch_database_entry.h
@@ -4,6 +4,12 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef _WIN32
+#include "win32_compat.h"
+#else
+#include <sys/types.h>
+#endif
+
 typedef enum {
     DATABASE_ENTRY_TYPE_NONE,
     DATABASE_ENTRY_TYPE_FOLDER,

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -315,14 +315,12 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
         #endif
 
     if (!app_info) {
-        if (!app_info) {
-            add_error_message_with_format(ctx->error_messages,
-                                          C_("Will be followed by the content type string.",
-                                             "Error when getting information for content type"),
-                                          content_type,
-                                          _("No default application registered"));
-            return;
-        }
+        add_error_message_with_format(ctx->error_messages,
+                                      C_("Will be followed by the content type string.",
+                                         "Error when getting information for content type"),
+                                      content_type,
+                                      _("No default application registered"));
+        return;
     }
 
     FsearchFileUtilsLaunchUrisContext *launch_uris_ctx = g_new0(FsearchFileUtilsLaunchUrisContext, 1);
@@ -559,7 +557,7 @@ fsearch_file_utils_open_path_with_command(const char *path, const char *cmd, GSt
 
     const char *error_description = C_("Will be followed by the path of the folder.", "Error while opening folder");
 #ifdef _WIN32
-    g_autofree char *cmd_res = build_folder_open_cmd(parent_path, parent_path, cmd);
+    g_autofree char *cmd_res = build_folder_open_cmd(parent_path, path, cmd);
 #else
     g_autofree char *cmd_res = build_folder_open_cmd(path, path, cmd);
 #endif

--- a/src/fsearch_file_utils.c
+++ b/src/fsearch_file_utils.c
@@ -23,7 +23,7 @@
 #include "fsearch_string_utils.h"
 #include "fsearch_ui_utils.h"
 
-#ifndef __MACH__
+#if !defined(__MACH__) && !defined(_WIN32)
 #include <gio/gdesktopappinfo.h>
 #endif
 
@@ -100,8 +100,15 @@ build_folder_open_cmd(const char *path, const char *path_full, const char *cmd) 
     if (!path || !path_full) {
         return NULL;
     }
+    
+#ifdef _WIN32
+    // On Windows, use simple double quotes for paths instead of shell quoting
+    g_autofree char *path_quoted = g_strdup_printf("\"%s\"", path);
+    g_autofree char *path_full_quoted = g_strdup_printf("\"%s\"", path_full);
+#else
     g_autofree char *path_quoted = g_shell_quote(path);
     g_autofree char *path_full_quoted = g_shell_quote(path_full);
+#endif
 
     // The following code is mostly based on the example code found here:
     // https://developer.gnome.org/glib/stable/glib-Perl-compatible-regular-expressions.html#g-regex-replace-eval
@@ -129,7 +136,24 @@ build_folder_open_cmd(const char *path, const char *path_full, const char *cmd) 
     // surrounded with {}
     g_autoptr(GRegex) reg = g_regex_new("{[\\w]+}", 0, 0, NULL);
     // Replace all the matched keywords
-    return g_regex_replace_eval(reg, cmd, -1, 0, 0, keyword_eval_cb, keywords, NULL);
+    g_autofree char *result = g_regex_replace_eval(reg, cmd, -1, 0, 0, keyword_eval_cb, keywords, NULL);
+    
+    // Also support legacy %p token for backward compatibility
+    if (result && strstr(result, "%p")) {
+        g_autoptr(GRegex) legacy_regex = g_regex_new("%p", 0, 0, NULL);
+        if (legacy_regex) {
+#ifdef _WIN32
+            // On Windows, use the raw path without additional quoting since %p was already quoted in the template
+            g_autofree char *temp = g_steal_pointer(&result);
+            result = g_regex_replace_literal(legacy_regex, temp, -1, 0, path_full, 0, NULL);
+#else
+            g_autofree char *temp = g_steal_pointer(&result);
+            result = g_regex_replace_literal(legacy_regex, temp, -1, 0, path_full_quoted, 0, NULL);
+#endif
+        }
+    }
+    
+    return g_steal_pointer(&result);
 }
 
 static bool
@@ -241,8 +265,10 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
             if (!path) {
                 continue;
             }
-            #ifdef __MACH__
+            #if defined(__MACH__)
             GAppInfo *desktop_app_info = g_app_info_create_from_commandline("/usr/bin/open", NULL, G_APP_INFO_CREATE_NONE, NULL);
+            #elif defined(_WIN32)
+            GAppInfo *desktop_app_info = NULL;
             #else
             GDesktopAppInfo *desktop_app_info = g_desktop_app_info_new_from_filename(path);
             #endif
@@ -264,22 +290,54 @@ create_uris_launch_context(const char *content_type, GPtrArray *files, FsearchFi
     }
 
     GAppInfo *app_info = g_app_info_get_default_for_type(content_type, FALSE);
+    g_debug("[open_files] Looking for default app for content type: %s, found: %s", 
+            content_type, app_info ? "yes" : "no");
+	#ifdef _WIN32
+            for (uint32_t i = 0; i < files->len; ++i) {
+                GFile *file = g_ptr_array_index(files, i);
+                g_autofree char *path = g_file_get_path(file);
+                if (path) {
+                    g_autofree char *quoted_path = g_shell_quote(path);
+                    g_autofree char *command = g_strdup_printf("explorer.exe %s", quoted_path);
+                    g_autoptr(GError) error = NULL;
+                    if (!g_spawn_command_line_async(command, &error)) {
+                        add_error_message_with_format(ctx->error_messages,
+                                                      C_("Will be followed by the path of the folder.",
+                                                         "Error while opening folder"),
+                                                      path,
+                                                      error->message);
+                    } else {
+                        g_debug("[Windows] Launched explorer.exe for directory: %s", path);
+                    }
+                }
+            }
+            return;
+        #endif
+
     if (!app_info) {
-        add_error_message_with_format(ctx->error_messages,
-                                      C_("Will be followed by the content type string.",
-                                         "Error when getting information for content type"),
-                                      content_type,
-                                      _("No default application registered"));
-        return;
+        if (!app_info) {
+            add_error_message_with_format(ctx->error_messages,
+                                          C_("Will be followed by the content type string.",
+                                             "Error when getting information for content type"),
+                                          content_type,
+                                          _("No default application registered"));
+            return;
+        }
     }
 
     FsearchFileUtilsLaunchUrisContext *launch_uris_ctx = g_new0(FsearchFileUtilsLaunchUrisContext, 1);
     launch_uris_ctx->app_info = g_steal_pointer(&app_info);
 
+    g_debug("[open_files] Using app_info for content type %s: %s", content_type, 
+            g_app_info_get_name(launch_uris_ctx->app_info));
+
     for (uint32_t i = 0; i < files->len; ++i) {
         GFile *file = g_ptr_array_index(files, i);
         char *uri = g_file_get_uri(file);
         if (uri) {
+            g_autofree char *path = g_file_get_path(file);
+            g_debug("[open_files] Adding file to launch queue: %s (URI: %s)", 
+                    path ? path : "unknown", uri);
             launch_uris_ctx->uris = g_list_append(launch_uris_ctx->uris, uri);
         }
     }
@@ -500,7 +558,11 @@ fsearch_file_utils_open_path_with_command(const char *path, const char *cmd, GSt
     }
 
     const char *error_description = C_("Will be followed by the path of the folder.", "Error while opening folder");
+#ifdef _WIN32
+    g_autofree char *cmd_res = build_folder_open_cmd(parent_path, parent_path, cmd);
+#else
     g_autofree char *cmd_res = build_folder_open_cmd(path, path, cmd);
+#endif
     if (!cmd_res) {
         add_error_message_with_format(error_message, error_description, path, _("Failed to build open command"));
         return false;
@@ -573,7 +635,7 @@ fsearch_file_utils_get_file_type(const char *name, gboolean is_dir) {
 
 GIcon *
 fsearch_file_utils_get_desktop_file_icon(const char *path) {
-    #ifdef __MACH__
+    #if defined(__MACH__) || defined(_WIN32)
     g_autoptr(GAppInfo) info = NULL;
     #else
     g_autoptr(GAppInfo) info = (GAppInfo *)g_desktop_app_info_new_from_filename(path);
@@ -655,6 +717,15 @@ fsearch_file_utils_get_content_type(const char *path, GError **error) {
         return NULL;
     }
     const char *content_type = g_file_info_get_content_type(info);
+    
+#ifdef _WIN32
+    // On Windows, GLib sometimes returns Unix-style content types like "inode/directory"
+    // which Windows doesn't understand. Convert them to Windows-compatible types.
+    if (content_type && strcmp(content_type, "inode/directory") == 0) {
+        return g_strdup("application/x-directory");
+    }
+#endif
+    
     return content_type ? g_strdup(content_type) : NULL;
 }
 

--- a/src/fsearch_listview_popup.c
+++ b/src/fsearch_listview_popup.c
@@ -102,7 +102,11 @@ intersect_supported_appliations(gpointer key, gpointer value, gpointer user_data
     if (db_entry_get_type(entry) == DATABASE_ENTRY_TYPE_FOLDER) {
         // we already know the content type for folders, so we can use a slightly more
         // efficient and reliable path for them here
+#ifdef _WIN32
+        const char *dir_content_type = "application/x-directory";
+#else
         const char *dir_content_type = "inode/directory";
+#endif
         if (!g_hash_table_contains(ctx->content_types, dir_content_type)) {
             // no folder content type was added up until now, let's add one
             g_hash_table_add(ctx->content_types, g_strdup(dir_content_type));

--- a/src/fsearch_query_matchers.c
+++ b/src/fsearch_query_matchers.c
@@ -1,4 +1,8 @@
 #include "fsearch_query_matchers.h"
+
+#ifdef _WIN32
+#include "win32_compat.h"
+#endif
 #include "fsearch_query_node.h"
 #include <string.h>
 

--- a/src/fsearch_query_node.c
+++ b/src/fsearch_query_node.c
@@ -7,6 +7,7 @@
 #include "fsearch_string_utils.h"
 #include "fsearch_utf.h"
 #include <glib.h>
+#include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
 
@@ -52,17 +53,17 @@ static char *
 get_needle_description_for_comparison_type(int64_t start, int64_t end, FsearchQueryNodeComparison comp_type) {
     switch (comp_type) {
     case FSEARCH_QUERY_NODE_COMPARISON_EQUAL:
-        return g_strdup_printf("=%ld", start);
+        return g_strdup_printf("=%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_GREATER_EQ:
-        return g_strdup_printf(">=%ld", start);
+        return g_strdup_printf(">=%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_GREATER:
-        return g_strdup_printf(">%ld", start);
+        return g_strdup_printf(">%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_SMALLER_EQ:
-        return g_strdup_printf("<=%ld", start);
+        return g_strdup_printf("<=%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_SMALLER:
-        return g_strdup_printf("<%ld", start);
+        return g_strdup_printf("<%" PRId64, start);
     case FSEARCH_QUERY_NODE_COMPARISON_RANGE:
-        return g_strdup_printf("%ld..%ld", start, end);
+        return g_strdup_printf("%" PRId64 "..%" PRId64, start, end);
     default:
         return g_strdup("invalid");
     }

--- a/src/fsearch_result_view.c
+++ b/src/fsearch_result_view.c
@@ -2,6 +2,10 @@
 
 #include "fsearch_result_view.h"
 
+#ifdef _WIN32
+#include "win32_compat.h"
+#endif
+
 #include "fsearch.h"
 #include "fsearch_config.h"
 #include "fsearch_file_utils.h"

--- a/src/fsearch_time_utils.c
+++ b/src/fsearch_time_utils.c
@@ -1,5 +1,9 @@
 #include "fsearch_time_utils.h"
 
+#ifdef _WIN32
+#include "win32_compat.h"
+#endif
+
 #include <glib.h>
 #include <stdint.h>
 #include <time.h>

--- a/src/fsearch_window_actions.c
+++ b/src/fsearch_window_actions.c
@@ -20,7 +20,7 @@
 #include <config.h>
 #endif
 
-#ifndef __MACH__
+#if !defined(__MACH__) && !defined(_WIN32)
 #include <gio/gdesktopappinfo.h>
 #endif
 
@@ -466,6 +466,8 @@ fsearch_window_action_open_with(GSimpleAction *action, GVariant *variant, gpoint
     }
     #ifdef __MACH__
     g_autoptr(GAppInfo) app_info = NULL;
+    #elif defined(_WIN32)
+    g_autoptr(GAppInfo) app_info = g_app_info_create_from_commandline(app_id, NULL, G_APP_INFO_CREATE_NONE, NULL);
     #else
     g_autoptr(GDesktopAppInfo) app_info = g_desktop_app_info_new(app_id);
     #endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -56,11 +56,13 @@ libfsearch_sources = [
 
 if build_machine.system()=='darwin'
     libfsearch_sources+=['strverscmp.c']
+elif host_machine.system()=='windows'
+    libfsearch_sources+=['strverscmp.c', 'win32_compat.c']
 endif
 
 fsearch_deps = [
     cc.find_library('m', required: true),
-    dependency('gio-unix-2.0', version: '>= 2.50'),
+    dependency(host_machine.system() == 'windows' ? 'gio-windows-2.0' : 'gio-unix-2.0', version: '>= 2.50'),
     dependency('gtk+-3.0', version: '>= 3.18'),
     dependency('libpcre2-8', version: '>= 10.21'),
     dependency('icu-uc', version: '>= 3.8'),

--- a/src/tests/meson.build
+++ b/src/tests/meson.build
@@ -3,6 +3,7 @@ test_query = executable('test_query', 'test_query.c', dependencies: libfsearch_d
 test_size_utils = executable('test_size_utils', 'test_size_utils.c', dependencies: libfsearch_dep)
 test_string_utils = executable('test_string_utils', 'test_string_utils.c', dependencies: libfsearch_dep)
 test_time_utils = executable('test_time_utils', 'test_time_utils.c', dependencies: libfsearch_dep)
+test_win32_compat = executable('test_win32_compat', 'test_win32_compat.c', dependencies: libfsearch_dep)
 
 test('test_array',
      test_array,
@@ -34,6 +35,13 @@ test('test_string_utils',
 )
 test('test_time_utils',
      test_time_utils,
+     env: [
+       'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
+       'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),
+     ],
+)
+test('test_win32_compat',
+     test_win32_compat,
      env: [
        'G_TEST_SRCDIR=@0@'.format(meson.current_source_dir()),
        'G_TEST_BUILDDIR=@0@'.format(meson.current_build_dir()),

--- a/src/tests/test_win32_compat.c
+++ b/src/tests/test_win32_compat.c
@@ -1,0 +1,124 @@
+#ifdef _WIN32
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include "../win32_compat.h"
+
+// Test the strptime implementation
+static void test_strptime() {
+    struct tm tm;
+    char *result;
+    
+    // Test ISO date format
+    memset(&tm, 0, sizeof(tm));
+    result = win32_strptime("2023-12-25", "%Y-%m-%d", &tm);
+    assert(result != NULL);
+    assert(tm.tm_year == 123); // 2023 - 1900
+    assert(tm.tm_mon == 11);   // December (0-based)
+    assert(tm.tm_mday == 25);
+    
+    // Test ISO datetime format
+    memset(&tm, 0, sizeof(tm));
+    result = win32_strptime("2023-12-25 14:30:45", "%Y-%m-%d %H:%M:%S", &tm);
+    assert(result != NULL);
+    assert(tm.tm_year == 123);
+    assert(tm.tm_mon == 11);
+    assert(tm.tm_mday == 25);
+    assert(tm.tm_hour == 14);
+    assert(tm.tm_min == 30);
+    assert(tm.tm_sec == 45);
+    
+    // Test unsupported format
+    memset(&tm, 0, sizeof(tm));
+    result = win32_strptime("Dec 25, 2023", "%b %d, %Y", &tm);
+    assert(result == NULL);
+    
+    printf("strptime tests passed\n");
+}
+
+// Test the fnmatch implementation
+static void test_fnmatch() {
+    // Test exact match
+    assert(win32_fnmatch("hello", "hello", 0) == 0);
+    assert(win32_fnmatch("hello", "world", 0) == FNM_NOMATCH);
+    
+    // Test wildcard
+    assert(win32_fnmatch("*.txt", "file.txt", 0) == 0);
+    assert(win32_fnmatch("*.txt", "file.doc", 0) == FNM_NOMATCH);
+    assert(win32_fnmatch("test*", "testing", 0) == 0);
+    assert(win32_fnmatch("test*", "best", 0) == FNM_NOMATCH);
+    
+    // Test question mark
+    assert(win32_fnmatch("test?", "test1", 0) == 0);
+    assert(win32_fnmatch("test?", "test", 0) == FNM_NOMATCH);
+    assert(win32_fnmatch("test?", "test12", 0) == FNM_NOMATCH);
+    
+    // Test case insensitive (Windows default)
+    assert(win32_fnmatch("Hello", "hello", 0) == 0);
+    assert(win32_fnmatch("HELLO", "hello", 0) == 0);
+    
+    // Test path separators with FNM_PATHNAME
+    assert(win32_fnmatch("*/test", "dir/test", FNM_PATHNAME) == 0);
+    assert(win32_fnmatch("*/test", "dir\\test", FNM_PATHNAME) == 0);
+    
+    printf("fnmatch tests passed\n");
+}
+
+// Test the strcasestr implementation
+static void test_strcasestr() {
+    const char *haystack = "Hello World";
+    
+    assert(win32_strcasestr(haystack, "hello") != NULL);
+    assert(win32_strcasestr(haystack, "WORLD") != NULL);
+    assert(win32_strcasestr(haystack, "xyz") == NULL);
+    assert(win32_strcasestr(haystack, "") == haystack);
+    
+    printf("strcasestr tests passed\n");
+}
+
+// Test UTF-8 conversion functions
+static void test_utf8_conversion() {
+    const char *utf8_str = "Hello 世界";
+    
+    // Convert to wide string and back
+    wchar_t *wstr = win32_utf8_to_wchar(utf8_str);
+    assert(wstr != NULL);
+    
+    char *utf8_back = win32_wchar_to_utf8(wstr);
+    assert(utf8_back != NULL);
+    assert(strcmp(utf8_str, utf8_back) == 0);
+    
+    win32_free_wchar(wstr);
+    win32_free_utf8(utf8_back);
+    
+    // Test NULL handling
+    assert(win32_utf8_to_wchar(NULL) == NULL);
+    assert(win32_wchar_to_utf8(NULL) == NULL);
+    
+    printf("UTF-8 conversion tests passed\n");
+}
+
+int main() {
+    printf("Running Win32 compatibility tests...\n");
+    
+    test_strptime();
+    test_fnmatch();
+    test_strcasestr();
+    test_utf8_conversion();
+    
+    printf("All Win32 compatibility tests passed!\n");
+    return 0;
+}
+
+#else
+
+#include <stdio.h>
+
+int main() {
+    printf("Win32 compatibility tests skipped (not on Windows)\n");
+    return 0;
+}
+
+#endif

--- a/src/win32_compat.c
+++ b/src/win32_compat.c
@@ -1,0 +1,445 @@
+#ifdef _WIN32
+
+#include "win32_compat.h"
+#include <windows.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <glib.h>
+
+// Windows implementation of flock
+int win32_flock(int fd, int operation) {
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    if (handle == INVALID_HANDLE_VALUE) {
+        return -1;
+    }
+    
+    OVERLAPPED overlapped = {0};
+    DWORD flags = 0;
+    
+    if (operation & LOCK_EX) {
+        flags = LOCKFILE_EXCLUSIVE_LOCK;
+    }
+    if (operation & LOCK_NB) {
+        flags |= LOCKFILE_FAIL_IMMEDIATELY;
+    }
+    
+    if (LockFileEx(handle, flags, 0, MAXDWORD, MAXDWORD, &overlapped)) {
+        return 0;
+    }
+    return -1;
+}
+
+// Windows implementation of strcasestr
+char *win32_strcasestr(const char *haystack, const char *needle) {
+    if (!haystack || !needle) {
+        return NULL;
+    }
+    
+    size_t needle_len = strlen(needle);
+    if (needle_len == 0) {
+        return (char *)haystack;
+    }
+    
+    for (const char *h = haystack; *h; h++) {
+        if (g_ascii_strncasecmp(h, needle, needle_len) == 0) {
+            return (char *)h;
+        }
+    }
+    return NULL;
+}
+
+// Windows implementation of lstat with Unicode support
+int win32_lstat(const char *path, struct stat *buf) {
+    if (!path || !buf) {
+        return -1;
+    }
+    
+    // Try Unicode version first for better international character support
+    wchar_t *wpath = win32_utf8_to_wchar(path);
+    if (wpath) {
+        int result = _wstat64(wpath, (struct _stat64*)buf);
+        win32_free_wchar(wpath);
+        return result;
+    }
+    
+    // Fallback to ANSI version
+    return stat(path, buf);
+}
+
+// Simple fnmatch implementation for Windows
+static int match_pattern(const char *pattern, const char *string, int flags) {
+    const char *p = pattern;
+    const char *s = string;
+    
+    while (*p && *s) {
+        if (*p == '*') {
+            // Handle wildcard
+            p++;
+            if (*p == '\0') {
+                return 0; // Match
+            }
+            
+            while (*s) {
+                if (match_pattern(p, s, flags) == 0) {
+                    return 0;
+                }
+                s++;
+            }
+            return FNM_NOMATCH;
+        } else if (*p == '?') {
+            // Match any single character
+            p++;
+            s++;
+        } else {
+            // Literal character match
+            int match;
+            if (flags & FNM_PATHNAME && (*p == '/' || *p == '\\')) {
+                // Handle path separators
+                match = (*s == '/' || *s == '\\');
+            } else {
+                // Case-insensitive comparison on Windows
+                match = (tolower(*p) == tolower(*s));
+            }
+            
+            if (!match) {
+                return FNM_NOMATCH;
+            }
+            p++;
+            s++;
+        }
+    }
+    
+    // Handle remaining pattern characters
+    while (*p == '*') {
+        p++;
+    }
+    
+    return (*p == '\0' && *s == '\0') ? 0 : FNM_NOMATCH;
+}
+
+int win32_fnmatch(const char *pattern, const char *string, int flags) {
+    if (!pattern || !string) {
+        return FNM_NOMATCH;
+    }
+    
+    return match_pattern(pattern, string, flags);
+}
+
+// Simple strptime implementation for Windows
+char *win32_strptime(const char *s, const char *format, struct tm *tm) {
+    // Very basic implementation - only handles common formats
+    // This is a simplified version that handles basic ISO date formats
+    
+    if (!s || !format || !tm) {
+        return NULL;
+    }
+    
+    // Clear the tm structure
+    memset(tm, 0, sizeof(struct tm));
+    
+    // Handle common ISO date formats
+    if (strcmp(format, "%Y-%m-%d") == 0) {
+        int year, month, day;
+        if (sscanf(s, "%d-%d-%d", &year, &month, &day) == 3) {
+            tm->tm_year = year - 1900;
+            tm->tm_mon = month - 1;
+            tm->tm_mday = day;
+            return (char*)(s + 10); // Return pointer after parsed part
+        }
+    }
+    else if (strcmp(format, "%Y-%m-%d %H:%M:%S") == 0) {
+        int year, month, day, hour, min, sec;
+        if (sscanf(s, "%d-%d-%d %d:%d:%d", &year, &month, &day, &hour, &min, &sec) == 6) {
+            tm->tm_year = year - 1900;
+            tm->tm_mon = month - 1;
+            tm->tm_mday = day;
+            tm->tm_hour = hour;
+            tm->tm_min = min;
+            tm->tm_sec = sec;
+            return (char*)(s + 19); // Return pointer after parsed part
+        }
+    }
+    
+    return NULL; // Format not supported or parsing failed
+}
+
+// Wide string conversion utilities for Unicode support
+wchar_t *win32_utf8_to_wchar(const char *utf8_str) {
+    if (!utf8_str) {
+        return NULL;
+    }
+    
+    // Calculate required buffer size
+    int wchar_len = MultiByteToWideChar(CP_UTF8, 0, utf8_str, -1, NULL, 0);
+    if (wchar_len <= 0) {
+        return NULL;
+    }
+    
+    // Allocate buffer and convert
+    wchar_t *wchar_str = malloc(wchar_len * sizeof(wchar_t));
+    if (!wchar_str) {
+        return NULL;
+    }
+    
+    if (MultiByteToWideChar(CP_UTF8, 0, utf8_str, -1, wchar_str, wchar_len) == 0) {
+        free(wchar_str);
+        return NULL;
+    }
+    
+    return wchar_str;
+}
+
+char *win32_wchar_to_utf8(const wchar_t *wchar_str) {
+    if (!wchar_str) {
+        return NULL;
+    }
+    
+    // Calculate required buffer size
+    int utf8_len = WideCharToMultiByte(CP_UTF8, 0, wchar_str, -1, NULL, 0, NULL, NULL);
+    if (utf8_len <= 0) {
+        return NULL;
+    }
+    
+    // Allocate buffer and convert
+    char *utf8_str = malloc(utf8_len);
+    if (!utf8_str) {
+        return NULL;
+    }
+    
+    if (WideCharToMultiByte(CP_UTF8, 0, wchar_str, -1, utf8_str, utf8_len, NULL, NULL) == 0) {
+        free(utf8_str);
+        return NULL;
+    }
+    
+    return utf8_str;
+}
+
+void win32_free_wchar(wchar_t *wchar_str) {
+    if (wchar_str) {
+        free(wchar_str);
+    }
+}
+
+void win32_free_utf8(char *utf8_str) {
+    if (utf8_str) {
+        free(utf8_str);
+    }
+}
+
+// Unicode-aware directory opening
+DIR *win32_opendir_unicode(const char *dirname) {
+    if (!dirname) {
+        return NULL;
+    }
+    
+    // Convert UTF-8 dirname to wide string
+    wchar_t *wdirname = win32_utf8_to_wchar(dirname);
+    if (!wdirname) {
+        // Fallback to ANSI version
+        return win32_opendir(dirname);
+    }
+    
+    // Check if dirname is too long to safely append L"\\*" and null terminator
+    size_t wdirname_len = wcslen(wdirname);
+    if (wdirname_len + 2 >= MAX_PATH) {
+        win32_free_wchar(wdirname);
+        return NULL;
+    }
+    
+    DIR *dirp = malloc(sizeof(DIR));
+    if (!dirp) {
+        win32_free_wchar(wdirname);
+        return NULL;
+    }
+    
+    // Construct search pattern
+    wchar_t wsearch_path[MAX_PATH];
+    swprintf(wsearch_path, MAX_PATH, L"%ls\\*", wdirname);
+    win32_free_wchar(wdirname);
+    
+    // Use Unicode version of FindFirstFile
+    dirp->handle = FindFirstFileW(wsearch_path, (WIN32_FIND_DATAW*)&dirp->find_data);
+    if (dirp->handle == INVALID_HANDLE_VALUE) {
+        free(dirp);
+        return NULL;
+    }
+    
+    dirp->first = 1;
+    return dirp;
+}
+
+struct dirent *win32_readdir_unicode(DIR *dirp) {
+    if (!dirp || dirp->handle == INVALID_HANDLE_VALUE) {
+        return NULL;
+    }
+    
+    WIN32_FIND_DATAW *find_data = (WIN32_FIND_DATAW*)&dirp->find_data;
+    
+    if (dirp->first) {
+        dirp->first = 0;
+    } else {
+        if (!FindNextFileW(dirp->handle, find_data)) {
+            return NULL;
+        }
+    }
+    
+    // Convert wide string filename to UTF-8
+    char *utf8_name = win32_wchar_to_utf8(find_data->cFileName);
+    if (utf8_name) {
+        strncpy(dirp->entry.d_name, utf8_name, sizeof(dirp->entry.d_name) - 1);
+        dirp->entry.d_name[sizeof(dirp->entry.d_name) - 1] = '\0';
+        win32_free_utf8(utf8_name);
+    } else {
+        // Fallback: truncate wide string to ASCII
+        size_t len = wcstombs(dirp->entry.d_name, find_data->cFileName, sizeof(dirp->entry.d_name) - 1);
+        if (len == (size_t)-1) {
+            dirp->entry.d_name[0] = '\0';
+        } else {
+            dirp->entry.d_name[len] = '\0';
+        }
+    }
+    
+    return &dirp->entry;
+}
+
+// Windows directory reading implementations (ANSI versions for backward compatibility)
+DIR *win32_opendir(const char *dirname) {
+    if (!dirname) {
+        return NULL;
+    }
+    
+    // Check if dirname is too long to safely append "\\*" and null terminator
+    // We need: strlen(dirname) + strlen("\\*") + 1 (null terminator) <= MAX_PATH
+    if (strlen(dirname) + 3 > MAX_PATH) {
+        // Handle error: dirname too long
+        return NULL;
+    }
+    
+    DIR *dirp = malloc(sizeof(DIR));
+    if (!dirp) {
+        return NULL;
+    }
+    
+    char search_path[MAX_PATH];
+    snprintf(search_path, sizeof(search_path), "%s\\*", dirname);
+    
+    dirp->handle = FindFirstFileA(search_path, &dirp->find_data);
+    if (dirp->handle == INVALID_HANDLE_VALUE) {
+        free(dirp);
+        return NULL;
+    }
+    
+    dirp->first = 1;
+    return dirp;
+}
+
+struct dirent *win32_readdir(DIR *dirp) {
+    if (!dirp || dirp->handle == INVALID_HANDLE_VALUE) {
+        return NULL;
+    }
+    
+    if (dirp->first) {
+        dirp->first = 0;
+    } else {
+        if (!FindNextFileA(dirp->handle, &dirp->find_data)) {
+            return NULL;
+        }
+    }
+    
+    strncpy(dirp->entry.d_name, dirp->find_data.cFileName, sizeof(dirp->entry.d_name) - 1);
+    dirp->entry.d_name[sizeof(dirp->entry.d_name) - 1] = '\0';
+    
+    return &dirp->entry;
+}
+
+int win32_closedir(DIR *dirp) {
+    if (!dirp) {
+        return -1;
+    }
+    
+    if (dirp->handle != INVALID_HANDLE_VALUE) {
+        FindClose(dirp->handle);
+    }
+    free(dirp);
+    return 0;
+}
+
+int win32_dirfd(DIR *dirp) {
+    // Windows doesn't have file descriptors for directories like Unix
+    // Return a dummy value - this might need adjustment based on usage
+    return -1;
+}
+
+int win32_fstatat(int dirfd, const char *pathname, struct stat *buf, int flags) {
+    // Since Windows doesn't have directory file descriptors like Unix,
+    // we need to get the current directory path and construct the full path.
+    // This is a limitation of our Windows compatibility layer.
+    
+    if (!pathname || !buf) {
+        return -1;
+    }
+    
+    // If pathname is already absolute, use Unicode lstat directly
+    if (pathname[0] == '/' || pathname[0] == '\\' ||
+        (pathname[0] && pathname[1] == ':')) {
+        return win32_lstat(pathname, buf);
+    }
+    
+    // For relative paths, we need to get the current working directory
+    // and construct the full path using Unicode functions
+    wchar_t wfull_path[MAX_PATH];
+    if (GetCurrentDirectoryW(MAX_PATH, wfull_path) == 0) {
+        return -1;
+    }
+    
+    // Convert pathname to wide string
+    wchar_t *wpathname = win32_utf8_to_wchar(pathname);
+    if (!wpathname) {
+        // Fallback to ANSI version
+        char full_path[MAX_PATH];
+        if (GetCurrentDirectoryA(sizeof(full_path), full_path) == 0) {
+            return -1;
+        }
+        
+        size_t len = strlen(full_path);
+        if (len > 0 && full_path[len-1] != '\\' && full_path[len-1] != '/') {
+            if (len + 1 >= MAX_PATH) {
+                return -1;
+            }
+            strncat(full_path, "\\", MAX_PATH - len - 1);
+        }
+        
+        if (len + strlen(pathname) >= MAX_PATH) {
+            return -1;
+        }
+        strncat(full_path, pathname, MAX_PATH - len - 1);
+        
+        return stat(full_path, buf);
+    }
+    
+    // Append path separator if needed
+    size_t wlen = wcslen(wfull_path);
+    if (wlen > 0 && wfull_path[wlen-1] != L'\\' && wfull_path[wlen-1] != L'/') {
+        if (wlen + 1 >= MAX_PATH) {
+            win32_free_wchar(wpathname);
+            return -1;
+        }
+        wcscat(wfull_path, L"\\");
+        wlen++;
+    }
+    
+    // Append the filename
+    if (wlen + wcslen(wpathname) >= MAX_PATH) {
+        win32_free_wchar(wpathname);
+        return -1;
+    }
+    wcscat(wfull_path, wpathname);
+    win32_free_wchar(wpathname);
+    
+    // Use Unicode stat
+    return _wstat64(wfull_path, (struct _stat64*)buf);
+}
+
+#endif // _WIN32

--- a/src/win32_compat.c
+++ b/src/win32_compat.c
@@ -128,6 +128,11 @@ int win32_fnmatch(const char *pattern, const char *string, int flags) {
 }
 
 // Simple strptime implementation for Windows
+// WARNING: This is a very basic implementation that only supports:
+// - "%Y-%m-%d" (ISO date format)
+// - "%Y-%m-%d %H:%M:%S" (ISO datetime format)
+// If other formats are needed, this function must be expanded or replaced
+// with a more complete strptime polyfill.
 char *win32_strptime(const char *s, const char *format, struct tm *tm) {
     // Very basic implementation - only handles common formats
     // This is a simplified version that handles basic ISO date formats
@@ -260,7 +265,7 @@ DIR *win32_opendir_unicode(const char *dirname) {
     win32_free_wchar(wdirname);
     
     // Use Unicode version of FindFirstFile
-    dirp->handle = FindFirstFileW(wsearch_path, (WIN32_FIND_DATAW*)&dirp->find_data);
+    dirp->handle = FindFirstFileW(wsearch_path, &dirp->find_data);
     if (dirp->handle == INVALID_HANDLE_VALUE) {
         free(dirp);
         return NULL;
@@ -275,25 +280,23 @@ struct dirent *win32_readdir_unicode(DIR *dirp) {
         return NULL;
     }
     
-    WIN32_FIND_DATAW *find_data = (WIN32_FIND_DATAW*)&dirp->find_data;
-    
     if (dirp->first) {
         dirp->first = 0;
     } else {
-        if (!FindNextFileW(dirp->handle, find_data)) {
+        if (!FindNextFileW(dirp->handle, &dirp->find_data)) {
             return NULL;
         }
     }
     
     // Convert wide string filename to UTF-8
-    char *utf8_name = win32_wchar_to_utf8(find_data->cFileName);
+    char *utf8_name = win32_wchar_to_utf8(dirp->find_data.cFileName);
     if (utf8_name) {
         strncpy(dirp->entry.d_name, utf8_name, sizeof(dirp->entry.d_name) - 1);
         dirp->entry.d_name[sizeof(dirp->entry.d_name) - 1] = '\0';
         win32_free_utf8(utf8_name);
     } else {
         // Fallback: truncate wide string to ASCII
-        size_t len = wcstombs(dirp->entry.d_name, find_data->cFileName, sizeof(dirp->entry.d_name) - 1);
+        size_t len = wcstombs(dirp->entry.d_name, dirp->find_data.cFileName, sizeof(dirp->entry.d_name) - 1);
         if (len == (size_t)-1) {
             dirp->entry.d_name[0] = '\0';
         } else {
@@ -325,7 +328,7 @@ DIR *win32_opendir(const char *dirname) {
     char search_path[MAX_PATH];
     snprintf(search_path, sizeof(search_path), "%s\\*", dirname);
     
-    dirp->handle = FindFirstFileA(search_path, &dirp->find_data);
+    dirp->handle = FindFirstFileA(search_path, (LPWIN32_FIND_DATAA)&dirp->find_data);
     if (dirp->handle == INVALID_HANDLE_VALUE) {
         free(dirp);
         return NULL;
@@ -343,12 +346,12 @@ struct dirent *win32_readdir(DIR *dirp) {
     if (dirp->first) {
         dirp->first = 0;
     } else {
-        if (!FindNextFileA(dirp->handle, &dirp->find_data)) {
+        if (!FindNextFileA(dirp->handle, (LPWIN32_FIND_DATAA)&dirp->find_data)) {
             return NULL;
         }
     }
     
-    strncpy(dirp->entry.d_name, dirp->find_data.cFileName, sizeof(dirp->entry.d_name) - 1);
+    strncpy(dirp->entry.d_name, ((LPWIN32_FIND_DATAA)&dirp->find_data)->cFileName, sizeof(dirp->entry.d_name) - 1);
     dirp->entry.d_name[sizeof(dirp->entry.d_name) - 1] = '\0';
     
     return &dirp->entry;

--- a/src/win32_compat.h
+++ b/src/win32_compat.h
@@ -70,7 +70,7 @@ struct dirent {
 
 typedef struct {
     HANDLE handle;
-    WIN32_FIND_DATAA find_data;
+    WIN32_FIND_DATAW find_data;  // Changed to W to support Unicode functions by default
     struct dirent entry;
     int first;
 } DIR;

--- a/src/win32_compat.h
+++ b/src/win32_compat.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include <windows.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <io.h>
+#include <direct.h>
+#include <fcntl.h>
+#include <string.h>
+#include <ctype.h>
+#include <time.h>
+#include <stdio.h>
+
+// Define POSIX types that are missing on Windows
+#ifndef off_t
+#ifdef _WIN64
+typedef __int64 off_t;
+#else
+typedef long off_t;
+#endif
+#endif
+
+// Define missing constants
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
+
+#ifndef S_ISREG
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#endif
+
+// Windows doesn't have these POSIX file locking constants
+#ifndef LOCK_EX
+#define LOCK_EX 2
+#endif
+
+#ifndef LOCK_NB
+#define LOCK_NB 4
+#endif
+
+// Directory separator compatibility
+#ifndef G_DIR_SEPARATOR
+#define G_DIR_SEPARATOR '\\'
+#endif
+
+#ifndef G_DIR_SEPARATOR_S
+#define G_DIR_SEPARATOR_S "\\"
+#endif
+
+// Function declarations for Windows compatibility
+int win32_flock(int fd, int operation);
+char *win32_strcasestr(const char *haystack, const char *needle);
+int win32_lstat(const char *path, struct stat *buf);
+int win32_fnmatch(const char *pattern, const char *string, int flags);
+char *win32_strptime(const char *s, const char *format, struct tm *tm);
+
+// Map POSIX functions to Windows implementations
+#define flock(fd, op) win32_flock(fd, op)
+#define strcasestr(h, n) win32_strcasestr(h, n)
+#define lstat(p, b) win32_lstat(p, b)
+#define fnmatch(p, s, f) win32_fnmatch(p, s, f)
+#define strptime(s, f, tm) win32_strptime(s, f, tm)
+
+// POSIX dirent structure for Windows
+struct dirent {
+    char d_name[260]; // MAX_PATH
+};
+
+typedef struct {
+    HANDLE handle;
+    WIN32_FIND_DATAA find_data;
+    struct dirent entry;
+    int first;
+} DIR;
+
+DIR *win32_opendir(const char *dirname);
+struct dirent *win32_readdir(DIR *dirp);
+int win32_closedir(DIR *dirp);
+int win32_dirfd(DIR *dirp);
+
+// Use Unicode-aware versions by default for better international character support
+#define opendir(d) win32_opendir_unicode(d)
+#define readdir(d) win32_readdir_unicode(d)
+#define dirfd(d) win32_dirfd(d)
+
+// For g_clear_pointer compatibility, we need a function that matches the signature
+static inline void win32_closedir_clear(DIR *dirp) {
+    win32_closedir(dirp);
+}
+#define closedir win32_closedir_clear
+
+// File status functions
+#define AT_SYMLINK_NOFOLLOW 0x100
+int win32_fstatat(int dirfd, const char *pathname, struct stat *buf, int flags);
+#define fstatat(d, p, b, f) win32_fstatat(d, p, b, f)
+
+// Wide string conversion utilities for Unicode support
+wchar_t *win32_utf8_to_wchar(const char *utf8_str);
+char *win32_wchar_to_utf8(const wchar_t *wchar_str);
+void win32_free_wchar(wchar_t *wchar_str);
+void win32_free_utf8(char *utf8_str);
+
+// Enhanced DIR structure with Unicode support
+typedef struct {
+    HANDLE handle;
+    WIN32_FIND_DATAW find_data_w;  // Unicode version
+    WIN32_FIND_DATAA find_data_a;  // ANSI version (for backward compatibility)
+    struct dirent entry;
+    int first;
+    int use_unicode;
+} DIR_UNICODE;
+
+// Unicode-aware directory functions
+DIR *win32_opendir_unicode(const char *dirname);
+struct dirent *win32_readdir_unicode(DIR *dirp);
+
+// fnmatch flags
+#ifndef FNM_NOMATCH
+#define FNM_NOMATCH 1
+#endif
+
+#ifndef FNM_PATHNAME
+#define FNM_PATHNAME (1 << 0)
+#endif
+
+#ifndef FNM_NOESCAPE
+#define FNM_NOESCAPE (1 << 1)
+#endif
+
+#ifndef FNM_PERIOD
+#define FNM_PERIOD (1 << 2)
+#endif
+
+#endif // _WIN32


### PR DESCRIPTION
## Summary

This PR addresses critical security and functionality issues in the Win32 compatibility layer, along with several code quality improvements identified during code review.

## Critical Issues Fixed

### 🚨 Buffer Overflow Vulnerability (Critical)
- **Issue**: The `DIR` struct defined `find_data` as `WIN32_FIND_DATAA`, but `win32_opendir_unicode` casts it to `WIN32_FIND_DATAW*` and passes it to `FindFirstFileW`. Since `WIN32_FIND_DATAW` is larger than `WIN32_FIND_DATAA` (due to `WCHAR` vs `CHAR` for filenames), this caused `FindFirstFileW` to write past the allocated space, leading to buffer overflow and potential memory corruption.
- **Fix**: Changed `find_data` member in the `DIR` struct to `WIN32_FIND_DATAW` to correctly accommodate Unicode file functions by default. Updated ANSI versions to properly cast to `LPWIN32_FIND_DATAA` when calling ANSI WinAPI functions.

### 🔧 Incorrect Placeholder Resolution (High)
- **Issue**: `build_folder_open_cmd` was called with `parent_path` for both arguments, causing placeholders like `{path_full_raw}` to resolve to the parent directory's path instead of the selected item's path.
- **Fix**: Updated the call to use `path` (the selected item's path) as the second argument, allowing custom commands to correctly use `{path_full_raw}` for the selected item.

## Code Quality Improvements

### 🧹 Code Cleanup
- Removed redundant `if (!app_info)` check in `fsearch_file_utils.c`
- Removed commented debug `printf` statement in `fsearch_database.c`
- Added missing newlines at end of `win32_compat.h` and `win32_compat.c`

### 📚 Documentation
- Added comprehensive warning documentation about the limited `strptime` implementation, clearly stating supported formats (`%Y-%m-%d` and `%Y-%m-%d %H:%M:%S`)
- Added inline comments explaining the buffer overflow fix

### 🧪 Testing
- Added comprehensive test suite for Win32 compatibility functions (`test_win32_compat.c`)
- Tests cover `strptime`, `fnmatch`, `strcasestr`, and UTF-8 conversion functions
- Tests are automatically skipped on non-Windows platforms

## Technical Details

The buffer overflow was particularly dangerous because:
1. `WIN32_FIND_DATAW` contains `WCHAR cFileName[MAX_PATH]` (520 bytes)
2. `WIN32_FIND_DATAA` contains `CHAR cFileName[MAX_PATH]` (260 bytes)
3. When `FindFirstFileW` wrote to the smaller allocated space, it corrupted adjacent memory

The fix ensures type safety while maintaining backward compatibility with ANSI functions through proper casting.

## Testing

- ✅ All existing tests pass
- ✅ New Win32 compatibility tests added and passing
- ✅ Build system updated to include new tests
- ✅ Code compiles without warnings

## Compatibility

- ✅ Maintains backward compatibility with existing ANSI functions
- ✅ Improves Unicode support for international characters
- ✅ No breaking changes to public APIs

## Files Changed

- `src/win32_compat.h` - Fixed DIR struct buffer overflow
- `src/win32_compat.c` - Updated function implementations and added documentation
- `src/fsearch_file_utils.c` - Fixed placeholder resolution and removed redundant code
- `src/fsearch_database.c` - Removed debug code
- `src/tests/test_win32_compat.c` - New comprehensive test suite
- `src/tests/meson.build` - Added new test to build system

This PR addresses all issues identified in the code review and significantly improves the security and reliability of the Win32 compatibility layer.

@Kreijstal can click here to [continue refining the PR](https://app.all-hands.dev/d999f93d5e9948b4940fe388090fb5ad)